### PR TITLE
Update foundation.slider.js.es6, fix an error of slider

### DIFF
--- a/vendor/assets/js/foundation.slider.js.es6
+++ b/vendor/assets/js/foundation.slider.js.es6
@@ -292,7 +292,7 @@ class Slider {
       } else {
         barXY = eventFromBar;
       }
-      offsetPct = percent(barXY, barDim);
+      var offsetPct = percent(barXY, barDim);
 
       value = (this.options.end - this.options.start) * offsetPct + this.options.start;
 


### PR DESCRIPTION
Error log: Uncaught ReferenceError: offsetPct is not defined
It seems to let slider can not be used
